### PR TITLE
Fixes post playbook run

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ These instructions will allow anyone to deploy a Docker Swarm cluster onto an ab
 <!-- TOC -->
 
 - [Prerequisites](#prerequisites)
-- [Boostrapping VMs for Ansible](#boostrapping-vms-for-ansible)
+- [Boostrapping destination VMs for Ansible](#boostrapping-destination-vms-for-ansible)
 - [Deploying Swarm](#deploying-swarm)
 
 <!-- /TOC -->
@@ -20,7 +20,7 @@ These instructions will allow anyone to deploy a Docker Swarm cluster onto an ab
    ansible-galaxy install atosatto.docker-swarm
    ```
 
-## Boostrapping VMs for Ansible
+## Boostrapping destination VMs for Ansible
 
 Ansible connects to VMs using SFTP or SSH protocol for deployments. So for a one-click and no human intervention deployments to a VM, some setup is required.
 
@@ -30,12 +30,26 @@ Ansible connects to VMs using SFTP or SSH protocol for deployments. So for a one
 
 Script `bootstrap/setup.sh`, when run on each VM will setup the forementioned requirements.
 
+To bootstrap VMs **for each VM**, perform following steps:
+
+1. Login to VM as `root` user.
+2. Copy `bootstrap/setup.sh` to any location on the VM, say `/tmp`.
+3. **IMPORTANT:** Edit the script `bootstrap/setup.sh` and change the `publicKey` variable so that it has the public key of machine from where ansible playbook will be executed (usually user's laptop/desktop).
+4. Make the script runnable
+
+   ```sh
+   chmod u+x /tmp/setup.sh
+   ```
+
+5. Execute script to boostrap the VM.
+
 ## Deploying Swarm
 
 1. Prepare the Ansible inventory including all the hosts which will be part of Swarm cluster.
-2. Group up the hosts into `docker_swarm_manager` and `docker_swarm_worker`. Number of manager hosts must be 1, 3, 5 or 7. For Swarm's high-availability values >3 are suggested.
+2. Group up the hosts into `docker_swarm_manager` and `docker_swarm_worker`. Number of manager hosts must be 1, 3, 5 or 7. For Swarm's high-availability values >=3 are suggested.
 3. Run the Ansible playbook
 
    ```sh
-   ansible-playbook -i playbook/inventory playbook/deploy-swarm.sh
+   export ANSIBLE_REMOTE_USER=ansible
+   ansible-playbook -i playbook/inventory playbook/deploy-swarm.yml
    ```

--- a/bootstrap/setup.sh
+++ b/bootstrap/setup.sh
@@ -2,6 +2,8 @@
 
 set -eu -o pipefail
 
+publicKey="CHANGEME"
+
 main(){
     ensureGroup
     ensureUser
@@ -50,11 +52,11 @@ ensureUser(){
 
 # Add public key to authorized keys
 addAuthorizedPublicKey(){
-    local publicKey="ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEAvb7oAigUAxPJ0+oMEqxFf1pv2Jo3p7x50RuKkkI5zdJ170vqfQB6SzmCBlTl75lyT3Xune2u3uIF0sAomRPDeQYbVfGU8T2jl3JoZ4kr1YH26B0KlmZbU85P70a+kdFDs9/brj3MHPIWWSEi9BaL/T6cGni4HWAL7+ElCjqbGLh9MRoHwsxKb/BAQOU80Ea9mQp/A8h445h8KcMLFC3UhHKNYJFevrrBF6weH5K2y15BLB0yWDjiTX2v94R7coW1oj5ofLdgh2GJcwgB2diYw2jSC0eWTicI9dtuOLYEmMnDpr6Ff4+VRFYQJReuug2U0izLv5w/nT8P45WOVa0m8w== aku105@DELAKU10541878"
-
     # Covering bases if /home/ansible/.ssh didn't exist
     mkdir -p /home/ansible/.ssh && chmod 700 /home/ansible/.ssh
-    touch /home/ansible/.ssh/authorized_keys && chmod 600 /home/ansible/.ssh/authorized_keys
+    touch /home/ansible/.ssh/authorized_keys && \
+      chmod 600 /home/ansible/.ssh/authorized_keys && \
+      chown -R ansible.ansible /home/ansible/
 
     echo $publicKey >> /home/ansible/.ssh/authorized_keys
     info "Added public key to authorized keys."
@@ -69,17 +71,11 @@ ensurePython(){
         info "$python_version already installed."
         isPythonPresent="true"
     fi
-    # Check python3
-    if [ -n "$(which python3)" ]; then
-        local python_version=$(python3 -V)
-        info "$python_version already installed."
-        isPythonPresent="true"
-    fi
 
-    # Install python3 if not installed
+    # Install python2 if not installed
     if [ $isPythonPresent == "false" ]; then
         apt-get update
-        apt-get install -y python3
+        apt-get install -y python
         info "Installation finished."
     fi
 }

--- a/playbook/deploy-swarm.yml
+++ b/playbook/deploy-swarm.yml
@@ -1,4 +1,5 @@
 - name: "Provision Docker Swarm Cluster"
   hosts: all
+  become: yes
   roles:
     - { role: atosatto.docker-swarm }


### PR DESCRIPTION
While running the playbook for first time, we ran into some issues. This PR has the fixes that were applied:
- Before this change ansible user's home directory, `.ssh` dir and `authorized_keys` were owned by `root` user. Adding a `chown` command to fix ownership.
- Install python 2 because the Ansible module being used in not python 3 ready.
   - Don't check for python3 at all
- Playbook needs to run as `root` since Docker can only be installed as `root` user.
- Updated README:
   - to fix some incorrect information
   - to add detailed instructions for bootstrapping hosted VMs